### PR TITLE
Added pyproject.toml for poetry compabiliy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,32 @@
+[tool.poetry]
+name = "PytideNetworking"
+version = "0.1.0"
+description = "Python port of C# library Riptide."
+authors = ["Eric Bossecker <ebosseck@lunznet.de>"]
+# New attributes
+license = "MIT"
+readme = "README.md"
+homepage = "https://github.com/ebosseck/PytideNetworking"
+repository = "https://github.com/ebosseck/PytideNetworking"
+keywords = ["PytideNetworking", "networking", "Riptide"]
+classifiers = [
+    "Environment :: Console",
+    "Operating System :: OS Independent",
+    "Topic :: Software Development :: Documentation",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Software Development :: Quality Assurance",
+]
+include = [
+    "LICENSE",
+]
+
+[tool.poetry.dependencies]
+# Updated Python version
+python = "^3.6"
+
+[tool.poetry.dev-dependencies]
+pytest = "^3.0"
+
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "PytideNetworking"
 version = "0.1.0"
 description = "Python port of C# library Riptide."
-authors = ["Eric Bossecker <ebosseck@lunznet.de>"]
+authors = ["Eric Bossecker <poetry.pytide@mail-b.org>"]
 # New attributes
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
This pull request adds a `pyproject.toml` file in the root directory in order to make the project compatible with [poetry](https://python-poetry.org/).
## Usage
In your poetry project use
```
poetry add git+https://github.com/ebosseck/PytideNetworking.git
```
to add this project as an external dependency.
This should already be sufficient to be able to use the PytideNetworking library in your poetry project.

## Required Check
Please check the entered credentials (`authors`) and the external dependencies, which are listed under `[tool.poetry.dev-dependencies]` before merging.
