### PR TITLE
Compability for Python < 3.8

### DIFF
--- a/pytidenetworking/message.py
+++ b/pytidenetworking/message.py
@@ -1,4 +1,8 @@
-from typing import List, Literal, Union
+from typing import List, Union
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 from .message_base import MessageBase, MessageHeader, MessageSendMode
 from .utils.converter import fp32_to_bytes, fp64_to_bytes, bytes_to_fp32, bytes_to_fp64

--- a/pytidenetworking/message_base.py
+++ b/pytidenetworking/message_base.py
@@ -1,5 +1,9 @@
 from enum import IntEnum
-from typing import Literal, Union, List
+from typing import Union, List
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 BYTE_ORDER_LITTLE: Literal['big', 'little'] = "little"
 BYTE_ORDER_BIG: Literal['big', 'little'] = "big"

--- a/pytidenetworking/transports/tcp/tcp_connection.py
+++ b/pytidenetworking/transports/tcp/tcp_connection.py
@@ -1,4 +1,8 @@
-from typing import Tuple, List, Union, Literal
+from typing import Tuple, List, Union
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 from pytidenetworking.connection import Connection
 from pytidenetworking.peer import DisconnectReason

--- a/pytidenetworking/utils/converter.py
+++ b/pytidenetworking/utils/converter.py
@@ -1,5 +1,8 @@
 import struct
-from typing import Literal
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 
 FLOAT_LITTLE = "<f"


### PR DESCRIPTION
Tried implementing Pytide into Pymol.
This PR fixes occurring import errors of `Literal`.

Could also be solved differently if required.